### PR TITLE
Error message if index column not found

### DIFF
--- a/codegen/src/worktable/generator/index/mod.rs
+++ b/codegen/src/worktable/generator/index/mod.rs
@@ -2,7 +2,7 @@ mod cdc;
 mod info;
 mod usual;
 
-use crate::name_generator::{is_float, is_unsized, WorktableNameGenerator};
+use crate::name_generator::{WorktableNameGenerator, is_float, is_unsized};
 use crate::worktable::generator::Generator;
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
@@ -43,7 +43,9 @@ impl Generator {
             .indexes
             .iter()
             .map(|(i, idx)| {
-                let t = self.columns.columns_map.get(i).unwrap();
+                let Some(t) = self.columns.columns_map.get(i) else {
+                    panic!("cannot find column `{i}` in this table")
+                };
                 let t = if is_float(t.to_string().as_str()) {
                     quote! { OrderedFloat<#t> }
                 } else {
@@ -98,7 +100,9 @@ impl Generator {
             .indexes
             .iter()
             .map(|(i, idx)| {
-                let t = self.columns.columns_map.get(i).unwrap();
+                let Some(t) = self.columns.columns_map.get(i) else {
+                    panic!("cannot find column `{i}` in this table")
+                };
                 let t = if is_float(t.to_string().as_str()) {
                     quote! { OrderedFloat<#t> }
                 } else {


### PR DESCRIPTION
Unfortunately, the crate uses `proc_macro` and `unwrap` in code. It causes really unhelpful messages issues by the compiler as it gives zero context where `None` was instead of an expected `Option::Some`.

Ideally, the crate should use `proc_macro_error2` or any other fine crate for that. It requires a lot of efforts, so let it be just `panic` with something meaningful.