### PR TITLE
Some minor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["codegen", "examples", "performance_measurement", "performance_measur
 
 [package]
 name = "worktable"
-version = "0.8.21"
+version = "0.8.22"
 edition = "2024"
 authors = ["Handy-caT"]
 license = "MIT"
@@ -16,7 +16,7 @@ perf_measurements = ["dep:performance_measurement", "dep:performance_measurement
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-worktable_codegen = { path = "codegen", version = "=0.8.21" }
+worktable_codegen = { path = "codegen", version = "=0.8.22" }
 
 async-trait = "0.1.89"
 eyre = "0.6.12"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktable_codegen"
-version = "0.8.21"
+version = "0.8.22"
 edition = "2024"
 license = "MIT"
 description = "WorkTable codegeneration crate"

--- a/codegen/src/worktable/generator/primary_key.rs
+++ b/codegen/src/worktable/generator/primary_key.rs
@@ -81,6 +81,7 @@ impl Generator {
                 PartialOrd,
                 Ord,
                 SizeMeasure,
+                MemStat,
                 #unsized_derive
             )]
             #[rkyv(derive(PartialEq, Eq, PartialOrd, Ord, Debug))]

--- a/src/in_memory/pages.rs
+++ b/src/in_memory/pages.rs
@@ -230,7 +230,7 @@ where
         feature = "perf_measurements",
         performance_measurement(prefix_name = "DataPages")
     )]
-    pub fn select(&self, link: Link) -> Result<Row, ExecutionError>
+    pub fn select<L: Into<Link>>(&self, link: L) -> Result<Row, ExecutionError>
     where
         Row: Archive
             + for<'a> Serialize<
@@ -239,6 +239,7 @@ where
         <<Row as StorableRow>::WrappedRow as Archive>::Archived: Portable
             + Deserialize<<Row as StorableRow>::WrappedRow, HighDeserializer<rkyv::rancor::Error>>,
     {
+        let link = link.into();
         let pages = self.pages.read();
         let page = pages
             .get(page_id_mapper(link.page_id.into()))


### PR DESCRIPTION
Add `MemStat` derive for generated primary key type.
Allow `DataPages` select to be generic over input link type. Now it should just implement `Into<Link>`