### PR TITLE
fix: preserve sized indexed update path

### DIFF
--- a/codegen/src/generators/in_memory/queries/update.rs
+++ b/codegen/src/generators/in_memory/queries/update.rs
@@ -384,6 +384,11 @@ impl InMemoryGenerator {
                     return core::result::Result::Ok(());
                 }
             }
+        } else if self.columns.is_sized {
+            // A fixed-size row can always update archived fields in place. If
+            // one is indexed, finish_update applies the corresponding index
+            // diffs around that mutation.
+            quote! {}
         } else if touches_index {
             // Updating an indexed column must keep the index-maintaining
             // reinsert path, regardless of the row's storage shape.


### PR DESCRIPTION
Fixes the beta.6 Clippy failure caused by routing fixed-size indexed updates through the unsized reinsert branch. Restores the existing sized-row path before applying the new unsized fast-path conditions.

Validated with the exact default and all-features Clippy commands used by CI, both with warnings denied.