### PR TITLE
release: prepare 1.0.0-beta.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["codegen", "examples", "performance_measurement", "performance_measur
 
 [package]
 name = "worktable"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 edition = "2024"
 authors = ["Handy-caT"]
 license = "MIT"
@@ -66,7 +66,7 @@ tracing = "0.1"
 url = { version = "2", optional = true }
 uuid = { version = "1.24.0", features = ["v4", "v7"] }
 walkdir = { version = "2", optional = true }
-worktable_codegen = { path = "codegen", version = "=1.0.0-beta.6" }
+worktable_codegen = { path = "codegen", version = "=1.0.0-beta.7" }
 
 [dev-dependencies]
 chrono = "0.4.43"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worktable_codegen"
-version = "1.0.0-beta.6"
+version = "1.0.0-beta.7"
 edition = "2024"
 license = "MIT"
 description = "Proc-macro companion crate for worktable: the worktable! macro and its derives."


### PR DESCRIPTION
Bumps worktable and worktable_codegen to 1.0.0-beta.7 after the sized indexed-update Clippy hotfix.

Validated:
- default Clippy across workspace/all targets with warnings denied
- all-features Clippy across workspace/all targets with warnings denied
- workspace cargo check
- worktable_codegen beta.7 publish dry-run